### PR TITLE
Fix firestoreusers2json

### DIFF
--- a/auth/firestoreusers2json.js
+++ b/auth/firestoreusers2json.js
@@ -43,12 +43,11 @@ var serviceAccount = require("./firebase-service.json");
 try {
     admin.initializeApp({
         credential: admin.credential.cert(serviceAccount),
-        databaseURL: "https://" + serviceAccount.project_id + ".firebaseio.com" // "https://PROJECTID.firebaseio.com"
+        databaseURL: "https://".concat(serviceAccount.project_id, ".firebaseio.com") // "https://PROJECTID.firebaseio.com"
     });
 }
 catch (e) { }
 var args = process.argv.slice(2);
-//let db;
 if (args.length < 0) {
     console.log('Usage: node firestoreusers2json.js [<filename.json>] [<batch_size>]');
     console.log('   <filename.json>: (optional) output filename (defaults to ./users.json');
@@ -58,22 +57,25 @@ if (args.length < 0) {
 else {
     main();
 }
-var filename = args[0] || './users.json';
-var batch_size = args[1] || '100';
 function main() {
     return __awaiter(this, void 0, void 0, function () {
+        var filename, batchSizeInput, batchSize;
         return __generator(this, function (_a) {
-            fs.writeFileSync(filename, '[', 'utf-8');
-            listUsers();
+            filename = args[0] || "./users.json";
+            batchSizeInput = args[1] || "100";
+            batchSize = parseInt(batchSizeInput);
+            fs.writeFileSync(filename, "[", "utf-8");
+            listUsers(filename, batchSize);
             return [2 /*return*/];
         });
     });
 }
-var count = 0;
-function listUsers(nextPageToken) {
+function listUsers(filename, batchSize, nextPageToken) {
     return __awaiter(this, void 0, void 0, function () {
+        var count;
         return __generator(this, function (_a) {
-            admin.auth().listUsers(parseInt(batch_size), nextPageToken)
+            count = 0;
+            admin.auth().listUsers(batchSize, nextPageToken)
                 .then(function (usersFound) {
                 var users = usersFound.users;
                 users.forEach(function (user) {
@@ -81,7 +83,7 @@ function listUsers(nextPageToken) {
                     count++;
                 });
                 if (usersFound.pageToken) {
-                    listUsers(usersFound.pageToken);
+                    listUsers(filename, batchSize, usersFound.pageToken);
                 }
                 else {
                     fs.appendFileSync(filename, ']\n', 'utf-8');

--- a/auth/firestoreusers2json.ts
+++ b/auth/firestoreusers2json.ts
@@ -4,14 +4,13 @@ import * as admin from "firebase-admin";
 const serviceAccount = require("./firebase-service.json");
 
 try {
-  admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount),
-    databaseURL: `https://${serviceAccount.project_id}.firebaseio.com` // "https://PROJECTID.firebaseio.com"
-  });
+    admin.initializeApp({
+        credential: admin.credential.cert(serviceAccount),
+        databaseURL: `https://${serviceAccount.project_id}.firebaseio.com` // "https://PROJECTID.firebaseio.com"
+    });
 } catch (e) {}
 
 const args = process.argv.slice(2);
-//let db;
 
 if (args.length < 0) {
     console.log('Usage: node firestoreusers2json.js [<filename.json>] [<batch_size>]');
@@ -22,31 +21,34 @@ if (args.length < 0) {
     main();
 }
 
-const filename = args[0] || './users.json';
-const batch_size = args[1] || '100';
-
 async function main() {
-    fs.writeFileSync(filename, '[', 'utf-8');
-    listUsers();    
+    const filename = args[0] || "./users.json";
+    const batchSizeInput = args[1] || "100";
+    const batchSize = parseInt(batchSizeInput);
+    fs.writeFileSync(filename, "[", "utf-8");
+    listUsers(filename, batchSize);
 }
 
-let count = 0;
-async function listUsers(nextPageToken?: string) {
-        admin.auth().listUsers(parseInt(batch_size), nextPageToken)
-        .then((usersFound: admin.auth.ListUsersResult) => {
-            const users: admin.auth.UserRecord[] = usersFound.users;
-            users.forEach((user: admin.auth.UserRecord) => {
-                fs.appendFileSync(filename, (count > 0 ? ',' : '') + JSON.stringify(user, null, 2), 'utf-8');
-                count++;
-            });
-            if (usersFound.pageToken) {
-                listUsers(usersFound.pageToken);
-            } else {
-                fs.appendFileSync(filename, ']\n', 'utf-8');
-            }
-        }).catch((err) => {
-            console.log('ERROR in listUsers', JSON.stringify(err));
+
+async function listUsers(
+  filename: string,
+  batchSize: number,
+  nextPageToken?: string
+) {
+    let count = 0;
+    admin.auth().listUsers(batchSize, nextPageToken)
+    .then((usersFound: admin.auth.ListUsersResult) => {
+        const users: admin.auth.UserRecord[] = usersFound.users;
+        users.forEach((user: admin.auth.UserRecord) => {
+            fs.appendFileSync(filename, (count > 0 ? ',' : '') + JSON.stringify(user, null, 2), 'utf-8');
+            count++;
         });
+        if (usersFound.pageToken) {
+            listUsers(filename, batchSize, usersFound.pageToken);
+        } else {
+            fs.appendFileSync(filename, ']\n', 'utf-8');
+        }
+    }).catch((err) => {
+        console.log('ERROR in listUsers', JSON.stringify(err));
+    });
 }
-
-


### PR DESCRIPTION
### Changes
- fixes an apparent variable scoping issue in `firestoreusers2json.ts` which prevented the script from executing successfully. Seems that arguments from the CLI were not available in the `listUsers` function, so I passed them in explicitly.

```shell
auth git:(fix-firestoreusers2json) ✗ node firestoreusers2json.js
(node:95334) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string or an instance of Buffer or URL. Received undefined
    at Object.openSync (fs.js:454:10)
    at Object.writeFileSync (fs.js:1384:35)
    at /Users/tim/code/sauntimo/supabase-community/firebase-to-supabase/auth/firestoreusers2json.js:66:16
    at step (/Users/tim/code/sauntimo/supabase-community/firebase-to-supabase/auth/firestoreusers2json.js:33:23)
    at Object.next (/Users/tim/code/sauntimo/supabase-community/firebase-to-supabase/auth/firestoreusers2json.js:14:53)
    at /Users/tim/code/sauntimo/supabase-community/firebase-to-supabase/auth/firestoreusers2json.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/tim/code/sauntimo/supabase-community/firebase-to-supabase/auth/firestoreusers2json.js:4:12)
    at main (/Users/tim/code/sauntimo/supabase-community/firebase-to-supabase/auth/firestoreusers2json.js:64:12)
    at Object.<anonymous> (/Users/tim/code/sauntimo/supabase-community/firebase-to-supabase/auth/firestoreusers2json.js:59:5)
(node:95334) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:95334) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
- tries to standardise the indentation a little
- updates the related `.js` file (with `tsc firestoreusers2json.ts`) 
- Now successfully dumps firestore users in a json file 🙌 