### PR TITLE
fix bug with exporting multiple batches of firebase users

### DIFF
--- a/auth/firestoreusers2json.js
+++ b/auth/firestoreusers2json.js
@@ -83,6 +83,7 @@ function listUsers(filename, batchSize, nextPageToken) {
                     count++;
                 });
                 if (usersFound.pageToken) {
+                    fs.appendFileSync(filename, ',', 'utf-8');
                     listUsers(filename, batchSize, usersFound.pageToken);
                 }
                 else {

--- a/auth/firestoreusers2json.ts
+++ b/auth/firestoreusers2json.ts
@@ -44,6 +44,7 @@ async function listUsers(
             count++;
         });
         if (usersFound.pageToken) {
+            fs.appendFileSync(filename, ',', 'utf-8');
             listUsers(filename, batchSize, usersFound.pageToken);
         } else {
             fs.appendFileSync(filename, ']\n', 'utf-8');


### PR DESCRIPTION
## What kind of change does this PR introduce?
A bug fix for exporting multiple batches of firebase users

## What is the current behavior?
When exporting multiple batches of users from firebase, the json becomes invalid because it's missing a comma!

<img width="515" alt="image" src="https://user-images.githubusercontent.com/20890995/193422174-213f2efe-1912-4825-b055-1d21cf8b778c.png">
<img width="108" alt="image" src="https://user-images.githubusercontent.com/20890995/193422191-2c3a49c8-ba4e-4cdc-8572-88f40755bee9.png">

## What is the new behavior?
Adds an additional comma when exporting user json files

## Additional context

Add any other context or screenshots.
