### PR TITLE
docs: fix HOOKS.md example

### DIFF
--- a/firestore/HOOKS.md
+++ b/firestore/HOOKS.md
@@ -37,7 +37,7 @@ The parameters passed to your hook are:
 ##### Add a new (unique) numeric key to a collection
 ```js
 module.exports = (collectionName, doc, recordCounters, writeRecord) => {
-  doc.unique_key = (recordCounter[collectionName] + 1);
+  doc.unique_key = (recordCounters[collectionName] + 1);
   return doc;
 }
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes the `unique_key` documentation example (most likely a typo)

## What is the current behavior?

The `recordCounter` is undefined, the hook will fail silently and no records will be written to the JSON output.

## What is the new behavior?

The `unique_key` is correctly added to the document.