### PR TITLE
update Hooks readme

### DIFF
--- a/firestore/HOOKS.md
+++ b/firestore/HOOKS.md
@@ -9,7 +9,7 @@ Hooks allow you to customize the process of exporting a collection of Firestore 
 ## Writing a hook
 
 #### Create a .js file for your collection
-If your Firestore collection is called `users` then create a file called `users.js` in the current folder.
+If your Firestore collection is called `users` then create a file called `users_processDocument.js` in the same directory as the `firestore2json.js` script.
 
 #### Constructing your .js file
 The basic format of a hook file looks like this:

--- a/firestore/HOOKS.md
+++ b/firestore/HOOKS.md
@@ -37,7 +37,7 @@ The parameters passed to your hook are:
 ##### Add a new (unique) numeric key to a collection
 ```js
 module.exports = (collectionName, doc, recordCounters, writeRecord) => {
-  doc.unique_key = (recordCounter[collectionName] + 1);
+  doc.unique_key = (recordCounters[collectionName] + 1);
   return doc;
 }
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The current documentation incorrectly states the naming convention for hook files and doesn't specify their location. There's also a typo in one of the examples.

## What is the new behavior?

This PR updates the documentation to:

1. Correct the file naming convention from `users.js` to `users_processDocument.js`.
2. Specify that the hook file should be in the same directory as the `firestore2json.js` script.
3. Fix a typo in the first example (change `recordCounter` to `recordCounters`).

These changes align the documentation with the actual script behavior:

```javascript
if (fs.existsSync(`./${args[0]}_processDocument.js`)) {
    processDocument = require(`./${args[0]}_processDocument.js`);
}